### PR TITLE
Verify pdf parsing and rag pipeline functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A comprehensive pipeline for parsing PDF documents using IBM Granite's Docling m
 - **Smart Chunking**: Intelligent text splitting that preserves document structure
 - **Vector Search**: Fast similarity search using FAISS
 - **Embeddings**: Support for both Nomic cloud embeddings and local models
+- **LLM Integration**: Optional local LLM answering via Ollama (no paid API required)
 - **CLI Interface**: Rich command-line interface with interactive search
 - **Batch Processing**: Process entire directories of PDFs
 
@@ -25,10 +26,13 @@ cd pdf-rag-pipeline
 pip install -r requirements.txt
 ```
 
-3. Set up environment variables:
+3. Set up environment variables (optional):
 ```bash
 cp .env.example .env
-# Edit .env and add your Nomic API key
+# Edit .env and add your Nomic API key (optional)
+# Optionally set local LLM defaults
+# LLM_PROVIDER=ollama
+# LLM_MODEL=llama3.2
 ```
 
 ## Configuration
@@ -62,8 +66,8 @@ python cli.py parse document.pdf --use-local
 # Interactive search
 python cli.py search
 
-# Query with questions
-python cli.py query
+# Query with questions (generate answer with local Ollama)
+python cli.py query --llm-provider ollama --llm-model llama3.2
 
 # Show index statistics
 python cli.py stats
@@ -167,6 +171,36 @@ python cli.py parse document.pdf --use-local
 ```
 
 This will use the `all-MiniLM-L6-v2` model by default.
+
+### Using a Local LLM with Ollama
+
+Ensure Ollama is installed and a model is available (`ollama pull llama3.2`). Then:
+
+```bash
+python cli.py query --llm-provider ollama --llm-model llama3.2
+```
+
+Or set defaults in `.env`:
+
+```env
+LLM_PROVIDER=ollama
+LLM_MODEL=llama3.2
+```
+
+You can also use the Python API and the native `ollama` client directly:
+
+```python
+import ollama
+
+response = ollama.generate(model='llama3.2', prompt='Why is the sky blue?')
+print(response['response'])
+
+messages = [
+    {'role': 'user', 'content': 'Why is the sky blue?'}
+]
+chat_response = ollama.chat(model='llama3.2', messages=messages)
+print(chat_response['message']['content'])
+```
 
 ### Custom Chunking
 

--- a/cli.py
+++ b/cli.py
@@ -70,7 +70,7 @@ def parse(pdf_path, save_markdown, output_dir, use_local):
             if pdf_path.is_file():
                 # Process single PDF
                 task = progress.add_task(f"[cyan]Processing {pdf_path.name}...", total=None)
-                parsed_doc = pipeline.process_pdf(str(pdf_path), save_markdown=save_markdown)
+                parsed_doc = pipeline.process_pdf(str(pdf_path), save_markdown=save_markdown, output_dir=str(output_dir))
                 progress.update(task, completed=True)
                 
                 # Display results
@@ -92,7 +92,7 @@ def parse(pdf_path, save_markdown, output_dir, use_local):
             elif pdf_path.is_dir():
                 # Process directory
                 task = progress.add_task(f"[cyan]Processing PDFs in {pdf_path}...", total=None)
-                parsed_docs = pipeline.process_directory(str(pdf_path), save_markdown=save_markdown)
+                parsed_docs = pipeline.process_directory(str(pdf_path), save_markdown=save_markdown, output_dir=str(output_dir))
                 progress.update(task, completed=True)
                 
                 # Display results
@@ -135,12 +135,14 @@ def parse(pdf_path, save_markdown, output_dir, use_local):
 @cli.command()
 @click.option('--k', default=5, help='Number of results to return')
 @click.option('--use-local', is_flag=True, help='Use local embeddings instead of Nomic')
-def search(k, use_local):
+@click.option('--llm-provider', type=str, default=None, help="LLM provider (e.g., 'ollama')")
+@click.option('--llm-model', type=str, default=None, help="LLM model name (e.g., 'llama3.2')")
+def search(k, use_local, llm_provider, llm_model):
     """Interactive search interface."""
     try:
         # Initialize pipeline
         console.print("[cyan]Loading index...[/cyan]")
-        pipeline = RAGPipeline(use_local_embeddings=use_local)
+        pipeline = RAGPipeline(use_local_embeddings=use_local, llm_provider=llm_provider, llm_model=llm_model)
         
         # Check if index exists
         stats = pipeline.get_statistics()
@@ -197,12 +199,14 @@ def search(k, use_local):
 @cli.command()
 @click.option('--k', default=5, help='Number of documents to retrieve')
 @click.option('--use-local', is_flag=True, help='Use local embeddings instead of Nomic')
-def query(k, use_local):
+@click.option('--llm-provider', type=str, default=None, help="LLM provider (e.g., 'ollama')")
+@click.option('--llm-model', type=str, default=None, help="LLM model name (e.g., 'llama3.2')")
+def query(k, use_local, llm_provider, llm_model):
     """Query the RAG system with questions."""
     try:
         # Initialize pipeline
         console.print("[cyan]Loading index...[/cyan]")
-        pipeline = RAGPipeline(use_local_embeddings=use_local)
+        pipeline = RAGPipeline(use_local_embeddings=use_local, llm_provider=llm_provider, llm_model=llm_model)
         
         # Check if index exists
         stats = pipeline.get_statistics()
@@ -227,6 +231,7 @@ def query(k, use_local):
             # Display response
             console.print(f"\n[bold]Question:[/bold] {response['question']}")
             console.print(f"[bold]Retrieved {response['num_results']} relevant passages[/bold]\n")
+            console.print(f"[bold]Answer:[/bold] {response.get('answer', '')}\n")
             
             # Show sources
             if 'sources' in response:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ langchain==0.3.7
 langchain-community==0.3.5
 langchain-nomic==0.1.3
 sentence-transformers==3.0.1
+ollama==0.3.3
 
 # CLI and utilities
 click==8.1.7

--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,10 @@ class Settings(BaseSettings):
     
     # RAG Configuration
     top_k_results: int = Field(default=5, env="TOP_K_RESULTS")
+
+    # LLM Configuration
+    llm_provider: str = Field(default="", env="LLM_PROVIDER")  # e.g., 'ollama'
+    llm_model: str = Field(default="", env="LLM_MODEL")        # e.g., 'llama3.2'
     
     class Config:
         env_file = ".env"


### PR DESCRIPTION
Add Ollama LLM support for local answer generation and improve embedding/vector store robustness.

This PR integrates Ollama for local LLM answer generation in the `query` command, fulfilling the request for a fully local RAG pipeline without paid third-party services. It also includes critical fixes for embedding dimension tracking and `float32` dtype casting, ensuring robust operation with FAISS, and fully wires the `parse` command's `--output-dir` option.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4995a2b-8cf8-4428-b3f8-34a771aeb09a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4995a2b-8cf8-4428-b3f8-34a771aeb09a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

